### PR TITLE
Separate out and fix binary operators

### DIFF
--- a/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
+++ b/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
@@ -319,7 +319,7 @@ expr
  | expr ( '+' | '-' ) expr
  | expr ( '<<' | '>>' | '&' | '|' ) expr
  | expr ( '<' | '<=' | '>' | '>=' ) expr
- | expr ( '=' | '==' | '!=' | '<>' | K_IS | K_IS K_NOT | K_IN | K_LIKE | K_GLOB | K_MATCH | K_REGEXP ) expr
+ | expr ( '=' | '==' | '!=' | '<>' ) expr
  | expr K_AND expr
  | expr K_OR expr
  | function_name '(' ( K_DISTINCT? expr ( ',' expr )* | '*' )? ')'


### PR DESCRIPTION
The `IS` `IS NOT` `IN` `LIKE` `GLOB` `MATCH` `REGEXP` operators are all handled later in the expression grammar, but were being parsed as binary operators.

Example:

```
some_column IN (
  SELECT *
  FROM table
)
```

parses in to

```
expr
--expr
----column_name
--K_IN
--expr
----select_stmt
```

when it should parse to

```
expr
--expr
----column_name
--K_IN
--select_stmt
```
