### PR TITLE
Remove redundancy in with clauses

### DIFF
--- a/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
+++ b/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
@@ -102,7 +102,7 @@ commit_stmt
  ;
 
 compound_select_stmt
- : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+ : with_clause?
    select_core ( ( K_UNION K_ALL? | K_INTERSECT | K_EXCEPT ) select_core )+
    ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
    ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
@@ -175,7 +175,7 @@ drop_view_stmt
  ;
 
 factored_select_stmt
- : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+ : with_clause?
    select_core ( compound_operator select_core )*
    ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
    ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
@@ -220,13 +220,13 @@ savepoint_stmt
  ;
 
 simple_select_stmt
- : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+ : with_clause?
    select_core ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
    ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
  ;
 
 select_stmt
- : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+ : with_clause?
    select_or_values ( compound_operator select_or_values )*
    ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
    ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
@@ -372,7 +372,7 @@ table_constraint
  ;
 
 with_clause
- : K_WITH K_RECURSIVE? cte_table_name K_AS '(' select_stmt ')' ( ',' cte_table_name K_AS '(' select_stmt ')' )*
+ : K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )*
  ;
 
 qualified_table_name
@@ -438,10 +438,6 @@ compound_operator
  | K_UNION K_ALL
  | K_INTERSECT
  | K_EXCEPT
- ;
-
-cte_table_name
- : table_name ( '(' column_name ( ',' column_name )* ')' )?
  ;
 
 signed_number


### PR DESCRIPTION
I noticed that 

`common_table_expression` and `cte_table_name K_AS '(' select_stmt ')'` are equivalent

and

`( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?` and `with_clause?`

are equivalent.

This change makes it a little easier for consumers of the parsed model
