### PR TITLE
Bugfix: keywords may not occur in names

### DIFF
--- a/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
+++ b/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
@@ -277,7 +277,7 @@ type_name
 column_constraint
  : ( K_CONSTRAINT name )?
    ( K_PRIMARY K_KEY ( K_ASC | K_DESC )? conflict_clause K_AUTOINCREMENT?
-   | K_NOT? K_NULL conflict_clause
+   | K_NOT K_NULL conflict_clause
    | K_UNIQUE conflict_clause
    | K_CHECK '(' expr ')'
    | K_DEFAULT (signed_number | literal_value | '(' expr ')')
@@ -687,8 +687,7 @@ transaction_name
  ;
 
 any_name
- : IDENTIFIER 
- | keyword
+ : IDENTIFIER
  | STRING_LITERAL
  | '(' any_name ')'
  ;


### PR DESCRIPTION
I tried to parse SQL CREATE statements, but even parsing the most simple statements like 'CREATE TABLE "name" ("column" TEXT)' failed.
As far as I understood the grammar this was caused by the "any_name" declaration, since names could contains SQL keywords.
