### PR TITLE
Lower the precedence of the in operator

### DIFF
--- a/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
+++ b/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4
@@ -320,6 +320,11 @@ expr
  | expr ( '<<' | '>>' | '&' | '|' ) expr
  | expr ( '<' | '<=' | '>' | '>=' ) expr
  | expr ( '=' | '==' | '!=' | '<>' ) expr
+ | expr K_NOT? K_IN ( '(' ( select_stmt
+                          | expr ( ',' expr )*
+                          )? 
+                      ')'
+                    | ( database_name '.' )? table_name )
  | expr K_AND expr
  | expr K_OR expr
  | function_name '(' ( K_DISTINCT? expr ( ',' expr )* | '*' )? ')'
@@ -330,11 +335,6 @@ expr
  | expr ( K_ISNULL | K_NOTNULL | K_NOT K_NULL )
  | expr K_IS K_NOT? expr
  | expr K_NOT? K_BETWEEN expr K_AND expr
- | expr K_NOT? K_IN ( '(' ( select_stmt
-                          | expr ( ',' expr )*
-                          )? 
-                      ')'
-                    | ( database_name '.' )? table_name )
  | ( ( K_NOT )? K_EXISTS )? '(' select_stmt ')'
  | K_CASE expr? ( K_WHEN expr K_THEN expr )+ ( K_ELSE expr )? K_END
  | raise_function


### PR DESCRIPTION
Currently an expression like

``` sql
column1 = ? AND column2 IN (?, ?)
```

will parse down to
<img width="421" alt="screen shot 2016-10-04 at 1 41 49 pm" src="https://cloud.githubusercontent.com/assets/1675456/19085451/5b50f3a6-8a38-11e6-914a-e5e110a68617.png">

this change creates a parse tree like
<img width="454" alt="screen shot 2016-10-04 at 1 42 39 pm" src="https://cloud.githubusercontent.com/assets/1675456/19085479/7139596a-8a38-11e6-9c6c-b8544b97dc01.png">

which is the expected tree
